### PR TITLE
Add ondemand_cellular_excludes parameter in client config

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,8 +133,6 @@ on battery)
       ondemand_cellular_excludes => true,
     }
 
-
-
 The module will build and collect certs and configuration for your clients in
 `/etc/ipsec.d/dist/`, for example:
 

--- a/README.md
+++ b/README.md
@@ -111,22 +111,29 @@ class above.
 This module will export out the certs in a range of formats and sets up a mobile
 config file.
 
-Most of the params you won't need to set, however the following two are useful.
+Most of the params you won't need to set, however the following three are useful.
 By default the iOS configuration will be "connect on request" only, however you
 can adjust to ensure the VPN always automatically establishes a connection
 
     roadwarrior::client { 'examplephone':
-      ondemand_connect       => false,
-      ondemand_ssid_excludes => undef,
+      ondemand_connect           => false,
+      ondemand_ssid_excludes     => undef,
+      ondemand_cellular_excludes => false,
     }
 
 For example, to generate configuration for iOS that will always reconnect unless
 you are on WiFi network "home" or "bach" which presumably don't require the VPN.
+Additionally, you can specify that you trust your cellular provider and connection
+on cellular network don't require the VPN (additionally, this gives a positive effect
+on battery)
 
     roadwarrior::client { 'examplephone':
       ondemand_connect       => true,
       ondemand_ssid_excludes => ['home', 'bach'],
+      ondemand_cellular_excludes => true,
     }
+
+
 
 The module will build and collect certs and configuration for your clients in
 `/etc/ipsec.d/dist/`, for example:

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -6,6 +6,7 @@ define roadwarrior::client (
     $vpn_client              = $name,
     $ondemand_connect        = false,
     $ondemand_ssid_excludes  = undef,
+    $ondemand_cellular_excludes  = false,
     $vpn_name                = $::roadwarrior::vpn_name,
     $cert_dir                = $::roadwarrior::cert_dir,
     $cert_lifespan           = $::roadwarrior::cert_lifespan,

--- a/templates/ios.mobileconfig.erb
+++ b/templates/ios.mobileconfig.erb
@@ -96,6 +96,14 @@
 <% end -%>
 					</array>
 				</dict>
+<% if @ondemand_cellular_excludes -%>
+				<dict>
+					<key>Action</key>
+					<string>Disconnect</string>
+					<key>InterfaceTypeMatch</key>
+                       			<string>Cellular</string>
+				</dict>
+<% end -%>						
 <% end -%>
 				<dict>
 					<key>Action</key>


### PR DESCRIPTION
Additional parameter in client configuration. Adds cellular interface to safe list. VPN is not started in ondemand mode when client is on 2G, 3G, 4G, LTE etc. 

Significant impact on iPhone. Security versus battery life tradeoff. 