### PR TITLE
Satisfy dependencies for Ubuntu 18.04 LTS

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -7,7 +7,7 @@ class roadwarrior::params {
   # TODO: This will be Debian specific
   # Define all the packages we need for StrongSwan and the plugins (in particular EAP-TLS).
   # Note moreutils is there to provide additional tools to help with generating client config files.
-  $packages_strongswan = ['strongswan', 'strongswan-pki', 'libstrongswan-standard-plugins', 'libstrongswan-extra-plugins', 'libcharon-extra-plugins', 'moreutils']
+  $packages_strongswan = ['strongswan', 'strongswan-pki', 'libstrongswan-standard-plugins', 'libstrongswan-extra-plugins', 'libcharon-extra-plugins', 'iptables-persistent', 'moreutils']
 
   # TODO: This will (probably) be Debian specific
   # Define the name of the service.


### PR DESCRIPTION
Fix for issue #11 that I opened a few days ago. Turns out iptables-persistent is not installed by default in 18.04. After installing the package, no more iptables errors and no more firewall issues!